### PR TITLE
Add browser-based quiz with local leaderboard

### DIFF
--- a/quiz_app/index.html
+++ b/quiz_app/index.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Breaker Quiz Challenge</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="layout">
+      <section class="quiz-panel">
+        <header class="hero">
+          <h1>Breaker Quiz Challenge</h1>
+          <p class="tagline">
+            Play solo, submit your score, and climb the shared leaderboard.
+          </p>
+        </header>
+
+        <section id="start-screen" class="card">
+          <h2>How it works</h2>
+          <ol class="instructions">
+            <li>Start the quiz and answer each multiple-choice question.</li>
+            <li>Your score is based on the number of correct answers.</li>
+            <li>
+              Submit your name to post your result to the leaderboard shared on
+              this device.
+            </li>
+          </ol>
+          <button id="start-quiz" class="primary">Start quiz</button>
+        </section>
+
+        <section id="quiz-screen" class="card hidden" aria-live="polite">
+          <div class="progress" id="progress-text"></div>
+          <h2 id="question-text"></h2>
+          <div id="options-container" class="options" role="list"></div>
+          <button id="next-question" class="primary" disabled>
+            Next question
+          </button>
+          <p id="feedback" class="feedback" aria-live="assertive"></p>
+        </section>
+
+        <section id="result-screen" class="card hidden">
+          <h2>Results</h2>
+          <p id="score-summary"></p>
+          <p id="time-summary"></p>
+
+          <div class="submit-score">
+            <label class="input-group">
+              <span>Your name</span>
+              <input
+                id="player-name"
+                name="player-name"
+                type="text"
+                maxlength="40"
+                autocomplete="name"
+                placeholder="Enter your name"
+                required
+              />
+            </label>
+            <button id="submit-score" class="primary">Save to leaderboard</button>
+            <p id="result-message" class="feedback" aria-live="assertive"></p>
+          </div>
+
+          <div class="actions">
+            <button id="play-again" class="secondary">Play again</button>
+          </div>
+        </section>
+      </section>
+
+      <aside class="leaderboard-panel card" aria-live="polite">
+        <h2>Leaderboard</h2>
+        <p class="smallprint">
+          Results are stored locally so everyone using this device can compare
+          scores.
+        </p>
+        <ol id="leaderboard-list" class="leaderboard"></ol>
+        <button id="reset-leaderboard" class="link-button">Reset leaderboard</button>
+      </aside>
+    </main>
+
+    <footer class="footer">
+      <p>
+        Invite friends to take the challenge and see who tops the leaderboard!
+      </p>
+    </footer>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/quiz_app/script.js
+++ b/quiz_app/script.js
@@ -1,0 +1,268 @@
+const quizData = [
+  {
+    question: "Who popularised the phrase 'break the ice' in English literature?",
+    options: [
+      "William Shakespeare",
+      "Jane Austen",
+      "Charles Dickens",
+      "Mark Twain"
+    ],
+    answerIndex: 0
+  },
+  {
+    question: "What is the purpose of an icebreaker activity?",
+    options: [
+      "To provide detailed training content",
+      "To encourage people to relax and get to know each other",
+      "To measure productivity",
+      "To enforce strict schedules"
+    ],
+    answerIndex: 1
+  },
+  {
+    question: "Which of these is a common style of icebreaker question?",
+    options: [
+      "Asking participants to recite a poem",
+      "Discussing quarterly revenue reports",
+      "Sharing a surprising personal fact",
+      "Debating technical specifications"
+    ],
+    answerIndex: 2
+  },
+  {
+    question: "How long should a quick team icebreaker usually take?",
+    options: ["1-5 minutes", "20-30 minutes", "45-60 minutes", "More than an hour"],
+    answerIndex: 0
+  },
+  {
+    question: "What makes an effective quiz icebreaker for remote teams?",
+    options: [
+      "One that relies heavily on physical props",
+      "One that encourages everyone to participate via chat or video",
+      "One that excludes new team members",
+      "One that focuses on complex policies"
+    ],
+    answerIndex: 1
+  }
+];
+
+const leaderboardKey = "breakerQuizLeaderboard";
+
+let currentQuestionIndex = 0;
+let selectedOptionIndex = null;
+let score = 0;
+let quizStartedAt = null;
+let elapsedSeconds = 0;
+
+const startScreen = document.getElementById("start-screen");
+const quizScreen = document.getElementById("quiz-screen");
+const resultScreen = document.getElementById("result-screen");
+const startButton = document.getElementById("start-quiz");
+const nextButton = document.getElementById("next-question");
+const playAgainButton = document.getElementById("play-again");
+const submitButton = document.getElementById("submit-score");
+const resetButton = document.getElementById("reset-leaderboard");
+
+const questionText = document.getElementById("question-text");
+const optionsContainer = document.getElementById("options-container");
+const progressText = document.getElementById("progress-text");
+const feedback = document.getElementById("feedback");
+const scoreSummary = document.getElementById("score-summary");
+const timeSummary = document.getElementById("time-summary");
+const resultMessage = document.getElementById("result-message");
+const playerNameInput = document.getElementById("player-name");
+const leaderboardList = document.getElementById("leaderboard-list");
+
+startButton.addEventListener("click", startQuiz);
+nextButton.addEventListener("click", handleNextQuestion);
+playAgainButton.addEventListener("click", resetToStart);
+submitButton.addEventListener("click", submitScore);
+resetButton.addEventListener("click", resetLeaderboard);
+
+refreshLeaderboard();
+
+function startQuiz() {
+  score = 0;
+  currentQuestionIndex = 0;
+  selectedOptionIndex = null;
+  quizStartedAt = Date.now();
+  elapsedSeconds = 0;
+
+  startScreen.classList.add("hidden");
+  resultScreen.classList.add("hidden");
+  quizScreen.classList.remove("hidden");
+  nextButton.disabled = true;
+  feedback.textContent = "";
+
+  renderQuestion();
+}
+
+function renderQuestion() {
+  const questionData = quizData[currentQuestionIndex];
+  questionText.textContent = questionData.question;
+  progressText.textContent = `Question ${currentQuestionIndex + 1} of ${
+    quizData.length
+  }`;
+
+  optionsContainer.innerHTML = "";
+  selectedOptionIndex = null;
+  nextButton.disabled = true;
+
+  questionData.options.forEach((option, index) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "option-button";
+    button.textContent = option;
+    button.dataset.index = index;
+    button.addEventListener("click", () => selectOption(button, index));
+    optionsContainer.appendChild(button);
+  });
+}
+
+function selectOption(button, index) {
+  selectedOptionIndex = index;
+  Array.from(optionsContainer.children).forEach((child) =>
+    child.classList.remove("selected")
+  );
+  button.classList.add("selected");
+  nextButton.disabled = false;
+  feedback.textContent = "";
+}
+
+function handleNextQuestion() {
+  if (selectedOptionIndex === null) {
+    feedback.textContent = "Please choose an answer to continue.";
+    return;
+  }
+
+  const questionData = quizData[currentQuestionIndex];
+  if (selectedOptionIndex === questionData.answerIndex) {
+    score += 1;
+  }
+
+  currentQuestionIndex += 1;
+
+  if (currentQuestionIndex < quizData.length) {
+    renderQuestion();
+  } else {
+    finishQuiz();
+  }
+}
+
+function finishQuiz() {
+  elapsedSeconds = Math.round((Date.now() - quizStartedAt) / 1000);
+  quizScreen.classList.add("hidden");
+  resultScreen.classList.remove("hidden");
+
+  scoreSummary.textContent = `You answered ${score} out of ${quizData.length} questions correctly.`;
+  timeSummary.textContent = `Completed in ${elapsedSeconds} second${
+    elapsedSeconds === 1 ? "" : "s"
+  }.`;
+  resultMessage.textContent = "";
+  submitButton.disabled = false;
+  playerNameInput.value = "";
+  playerNameInput.focus({ preventScroll: true });
+
+  refreshLeaderboard();
+}
+
+function resetToStart() {
+  resultScreen.classList.add("hidden");
+  quizScreen.classList.add("hidden");
+  startScreen.classList.remove("hidden");
+  resultMessage.textContent = "";
+  feedback.textContent = "";
+}
+
+function submitScore() {
+  const name = playerNameInput.value.trim();
+  if (!name) {
+    resultMessage.textContent = "Please enter your name before saving.";
+    playerNameInput.focus();
+    return;
+  }
+
+  const leaderboard = loadLeaderboard();
+  const entry = {
+    name,
+    score,
+    total: quizData.length,
+    time: elapsedSeconds,
+    timestamp: new Date().toISOString()
+  };
+
+  leaderboard.push(entry);
+  leaderboard.sort((a, b) => {
+    if (b.score !== a.score) {
+      return b.score - a.score;
+    }
+    return a.time - b.time;
+  });
+
+  const trimmed = leaderboard.slice(0, 20);
+  localStorage.setItem(leaderboardKey, JSON.stringify(trimmed));
+
+  resultMessage.textContent = "Score saved!";
+  submitButton.disabled = true;
+  refreshLeaderboard();
+}
+
+function loadLeaderboard() {
+  const stored = localStorage.getItem(leaderboardKey);
+  if (!stored) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(stored);
+    if (Array.isArray(parsed)) {
+      return parsed;
+    }
+  } catch (error) {
+    console.error("Unable to parse leaderboard", error);
+  }
+  return [];
+}
+
+function refreshLeaderboard() {
+  const leaderboard = loadLeaderboard();
+  leaderboardList.innerHTML = "";
+
+  if (leaderboard.length === 0) {
+    const emptyState = document.createElement("li");
+    emptyState.textContent = "No scores yet — be the first!";
+    leaderboardList.appendChild(emptyState);
+    return;
+  }
+
+  leaderboard.forEach((entry, index) => {
+    const item = document.createElement("li");
+
+    const rank = document.createElement("span");
+    rank.className = "rank";
+    rank.textContent = `#${index + 1}`;
+
+    const name = document.createElement("span");
+    name.className = "name";
+    name.textContent = entry.name;
+
+    const score = document.createElement("span");
+    score.className = "score";
+    score.textContent = `${entry.score}/${entry.total}`;
+
+    const time = document.createElement("span");
+    time.className = "time";
+    time.textContent = `${entry.time}s`;
+
+    item.append(rank, name, score, time);
+    leaderboardList.appendChild(item);
+  });
+}
+
+function resetLeaderboard() {
+  if (confirm("Clear all saved results from this device?")) {
+    localStorage.removeItem(leaderboardKey);
+    refreshLeaderboard();
+    resultMessage.textContent = "Leaderboard cleared.";
+  }
+}

--- a/quiz_app/styles.css
+++ b/quiz_app/styles.css
@@ -1,0 +1,290 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f4f5f7;
+  --card-bg: #ffffffee;
+  --accent: #4f46e5;
+  --accent-dark: #4338ca;
+  --text: #1f2933;
+  --muted: #4b5563;
+  --border: #e5e7eb;
+  font-family: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont,
+    "Helvetica Neue", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  background: linear-gradient(145deg, #eef2ff 0%, #f9fafb 100%);
+  color: var(--text);
+  line-height: 1.6;
+}
+
+.layout {
+  width: min(1100px, 92vw);
+  margin: 2rem auto;
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: 2fr 1fr;
+}
+
+.hero {
+  background: linear-gradient(135deg, var(--accent), #7c3aed);
+  color: #fff;
+  padding: 1.75rem;
+  border-radius: 1rem;
+  box-shadow: 0 12px 32px rgba(79, 70, 229, 0.25);
+}
+
+.hero h1 {
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+  margin-bottom: 0.35rem;
+}
+
+.hero .tagline {
+  font-size: 1rem;
+  opacity: 0.9;
+}
+
+.card {
+  background: var(--card-bg);
+  border-radius: 1rem;
+  padding: 1.75rem;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+  backdrop-filter: blur(4px);
+}
+
+.quiz-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.instructions {
+  display: grid;
+  gap: 0.75rem;
+  padding-left: 1.25rem;
+}
+
+.primary,
+.secondary,
+.link-button {
+  border: none;
+  border-radius: 999px;
+  cursor: pointer;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease,
+    color 0.2s ease;
+  padding: 0.8rem 1.5rem;
+}
+
+.primary {
+  background: var(--accent);
+  color: #fff;
+  box-shadow: 0 12px 24px rgba(79, 70, 229, 0.35);
+}
+
+.primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.primary:not(:disabled):hover,
+.primary:not(:disabled):focus-visible {
+  background: var(--accent-dark);
+  transform: translateY(-1px);
+}
+
+.secondary {
+  background: #ffffff;
+  color: var(--accent);
+  border: 2px solid rgba(79, 70, 229, 0.2);
+}
+
+.secondary:hover,
+.secondary:focus-visible {
+  background: rgba(79, 70, 229, 0.08);
+}
+
+.link-button {
+  background: none;
+  color: var(--muted);
+  padding-inline: 0;
+}
+
+.link-button:hover,
+.link-button:focus-visible {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
+.options {
+  display: grid;
+  gap: 0.75rem;
+  margin-block: 1.25rem;
+}
+
+.option-button {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  text-align: left;
+  border-radius: 0.85rem;
+  border: 2px solid transparent;
+  background: rgba(79, 70, 229, 0.05);
+  color: inherit;
+  cursor: pointer;
+  transition: border 0.2s ease, background 0.2s ease, transform 0.2s ease;
+}
+
+.option-button:hover,
+.option-button:focus-visible {
+  border-color: rgba(79, 70, 229, 0.35);
+  transform: translateY(-1px);
+}
+
+.option-button.selected {
+  background: rgba(79, 70, 229, 0.12);
+  border-color: var(--accent);
+  box-shadow: 0 8px 18px rgba(79, 70, 229, 0.25);
+}
+
+.progress {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--muted);
+  margin-bottom: 0.5rem;
+}
+
+.feedback {
+  margin-top: 0.75rem;
+  min-height: 1.25rem;
+  color: var(--muted);
+}
+
+.submit-score {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.input-group {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.input-group input {
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--border);
+  font-size: 1rem;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.input-group input:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.25);
+}
+
+.actions {
+  margin-top: 1.5rem;
+}
+
+.leaderboard-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-height: fit-content;
+}
+
+.smallprint {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.leaderboard {
+  list-style: none;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.leaderboard li {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background: rgba(79, 70, 229, 0.05);
+}
+
+.leaderboard li .rank {
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.leaderboard li .score {
+  font-weight: 600;
+}
+
+.leaderboard li .time {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.footer {
+  padding: 2rem 0 3rem;
+  text-align: center;
+  color: var(--muted);
+}
+
+.hidden {
+  display: none !important;
+}
+
+@media (max-width: 900px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .leaderboard-panel {
+    order: -1;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0f172a;
+    --card-bg: #1e293b;
+    --accent: #8b5cf6;
+    --accent-dark: #7c3aed;
+    --text: #f8fafc;
+    --muted: #cbd5f5;
+    --border: #334155;
+  }
+
+  body {
+    background: radial-gradient(circle at top left, #1e293b 0%, #0f172a 60%);
+  }
+
+  .card {
+    box-shadow: 0 20px 40px rgba(2, 6, 23, 0.55);
+  }
+
+  .option-button {
+    background: rgba(139, 92, 246, 0.14);
+  }
+
+  .leaderboard li {
+    background: rgba(139, 92, 246, 0.12);
+  }
+}


### PR DESCRIPTION
## Summary
- add a responsive HTML/CSS/JS quiz experience that guides players from instructions to results
- implement client-side scoring, timing, and a browser-backed leaderboard shared between participants on the same device
- style the layout with a hero section, cards, and dark-mode friendly colors for a polished presentation

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68c8ddf19920832a9560d85e34b507b4